### PR TITLE
Allow PIV_analyser to run in headless mode

### DIFF
--- a/src/main/java/PIV_analyser.java
+++ b/src/main/java/PIV_analyser.java
@@ -503,8 +503,10 @@ public class PIV_analyser implements PlugInFilter {
 		startAndJoin(threads);  
 
 		// Add the MouseMotionListener that "deconvolves" color
-		color_canvas = color_imp.getCanvas();
-		color_canvas.addMouseMotionListener(getColorMouseListener(winsize_x/2.0f));
+		if (show_calculation) {
+			color_canvas = color_imp.getCanvas();
+			color_canvas.addMouseMotionListener(getColorMouseListener(winsize_x/2.0f));
+		}
 		
 		// Return result as array of ImagePlus
 		return new ImagePlus[] { u_imp, v_imp, pkh_imp, color_imp };


### PR DESCRIPTION
Running `PIV_analyser` with `show_calculation = false` fails. Because `color_imp.show()` is not called, `color_imp.getCanvas()` returns null, and a `MouseMotionListener` cannot be added. Skipping the call to `addMouseListener` when `show_calculation = false` fixes the issue, allowing `PIV_analyser` to run in headless mode.